### PR TITLE
Adds config option to skip dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ AsktiveRecord.configure do |config|
   # This is used by the `asktive_record:setup` command and the `.ask` method to provide context to the LLM.
   # Default is "db/schema.rb".
   # config.db_schema_path = "db/schema.rb"
+
+  # === Skip dump schema ===
+  # If set to true, the schema will not be dumped when running the
+  # `asktive_record:setup` command.
+  # This is useful if you want to manage schema dumps manually
+  # or if you are using a different schema management strategy.
+  # config.skip_dump_schema = false
 end
 ```
 

--- a/lib/asktive_record/configuration.rb
+++ b/lib/asktive_record/configuration.rb
@@ -5,13 +5,14 @@ module AsktiveRecord
   # This class holds the configuration settings for the LLM provider, API key, model name
   # and database schema path.
   class Configuration
-    attr_accessor :llm_provider, :llm_api_key, :llm_model_name, :db_schema_path
+    attr_accessor :llm_provider, :llm_api_key, :llm_model_name, :db_schema_path, :skip_dump_schema
 
     def initialize
       @llm_provider = :openai # Default LLM provider
       @llm_api_key = nil
       @llm_model_name = "gpt-3.5-turbo" # Default model for OpenAI
       @db_schema_path = "db/schema.rb" # Default path for Rails schema file
+      @skip_dump_schema = false # Default is to not skip schema dump
     end
   end
 end

--- a/lib/asktive_record/model.rb
+++ b/lib/asktive_record/model.rb
@@ -47,7 +47,7 @@ module AsktiveRecord
       end
 
       def try_dump_schema(schema_path)
-        return unless defined?(Rails)
+        return unless defined?(Rails) && !AsktiveRecord.configuration.skip_dump_schema
 
         system("bin/rails db:schema:dump")
         File.exist?(schema_path) ? File.read(schema_path) : nil

--- a/lib/asktive_record/service.rb
+++ b/lib/asktive_record/service.rb
@@ -56,7 +56,7 @@ module AsktiveRecord
       end
 
       def fallback_schema_from_rails(path)
-        system("bin/rails db:schema:dump")
+        system("bin/rails db:schema:dump") unless AsktiveRecord.configuration.skip_dump_schema
         return File.read(path) if File.exist?(path)
 
         alt_path = "db/structure.sql"

--- a/lib/generators/asktive_record/setup_generator.rb
+++ b/lib/generators/asktive_record/setup_generator.rb
@@ -30,8 +30,7 @@ module AsktiveRecord
 
       def dump_and_read_schema(schema_path)
         puts "Attempting to dump database schema using 'rails db:schema:dump'..."
-        system("bin/rails db:schema:dump")
-
+        system("bin/rails db:schema:dump") unless AsktiveRecord.configuration.skip_dump_schema
         read_schema_file(schema_path) || read_structure_sql || schema_not_found_message(schema_path)
       rescue StandardError => e
         puts "Failed to execute 'rails db:schema:dump' or read schema: #{e.message}"

--- a/lib/generators/asktive_record/templates/asktive_record_initializer.rb
+++ b/lib/generators/asktive_record/templates/asktive_record_initializer.rb
@@ -24,4 +24,11 @@ AsktiveRecord.configure do |config|
   # This is used by the `asktive_record:setup` command to provide context to the LLM.
   # Default is "db/schema.rb".
   # config.db_schema_path = "db/schema.rb"
+  #
+  # === Skip dump schema ===
+  # If set to true, the schema will not be dumped when running the
+  # `asktive_record:setup` command.
+  # This is useful if you want to manage schema dumps manually
+  # or if you are using a different schema management strategy.
+  # config.skip_dump_schema = false
 end

--- a/spec/asktive_record/configuration_spec.rb
+++ b/spec/asktive_record/configuration_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe AsktiveRecord::Configuration do
       expect(config.llm_api_key).to be_nil
       expect(config.llm_model_name).to eq("gpt-3.5-turbo")
       expect(config.db_schema_path).to eq("db/schema.rb")
+      expect(config.skip_dump_schema).to eq(false)
     end
   end
 
@@ -21,11 +22,13 @@ RSpec.describe AsktiveRecord::Configuration do
       config.llm_api_key = "test_key"
       config.llm_model_name = "test_model"
       config.db_schema_path = "custom/schema.sql"
+      config.skip_dump_schema = true
 
       expect(config.llm_provider).to eq(:another_llm)
       expect(config.llm_api_key).to eq("test_key")
       expect(config.llm_model_name).to eq("test_model")
       expect(config.db_schema_path).to eq("custom/schema.sql")
+      expect(config.skip_dump_schema).to eq(true)
     end
   end
 end

--- a/spec/asktive_record/model_spec.rb
+++ b/spec/asktive_record/model_spec.rb
@@ -218,6 +218,7 @@ RSpec.describe AsktiveRecord do
       expect(AsktiveRecord.configuration.object_id).to eq(first_config_object_id)
       expect(AsktiveRecord.configuration.llm_api_key).to eq("first_key")
       expect(AsktiveRecord.configuration.llm_model_name).to eq("new_model")
+      expect(AsktiveRecord.configuration.skip_dump_schema).to eq(false)
     end
   end
 


### PR DESCRIPTION
If the host app has a rails db but it is a
lefacy or if you dont want to run the rails dump
command, add the config in the initialization file